### PR TITLE
Fix horizontal Mushaf paging stopping after initial pages

### DIFF
--- a/components/mushaf/PageMushaf.tsx
+++ b/components/mushaf/PageMushaf.tsx
@@ -290,6 +290,14 @@ export function PageMushaf({ onPageChange, goToPageRef, onScroll }: Props) {
     if (goToPageRef) {
       goToPageRef.current = (page: number) => {
         if (page >= 1 && page <= pageData.length) {
+          if (horizontal) {
+            flatListRef.current?.scrollToOffset({
+              offset: width * (page - 1),
+              animated: false,
+            });
+            return;
+          }
+
           flatListRef.current?.scrollToIndex({
             index: page - 1,
             animated: false,
@@ -297,7 +305,7 @@ export function PageMushaf({ onPageChange, goToPageRef, onScroll }: Props) {
         }
       };
     }
-  }, [goToPageRef, pageData.length]);
+  }, [goToPageRef, horizontal, pageData.length, width]);
 
   // Track which page is currently visible
   const viewabilityConfig = useRef({
@@ -374,7 +382,7 @@ export function PageMushaf({ onPageChange, goToPageRef, onScroll }: Props) {
         data={pageData}
         renderItem={renderPage}
         keyExtractor={keyExtractor}
-        getItemLayout={getItemLayout}
+        getItemLayout={horizontal ? undefined : getItemLayout}
         extraData={fontSize}
         horizontal={horizontal}
         pagingEnabled={horizontal}


### PR DESCRIPTION
### Motivation
- Horizontal page-swipe mode could stop materializing pages after the initial window (users reported being unable to swipe past ~6–7 pages), caused by VirtualizedList frame math when `getItemLayout` was used in horizontal mode.
- The go-to-page jump also needed to reliably position the FlatList in horizontal mode without relying on `scrollToIndex`/precomputed offsets.

### Description
- In `components/mushaf/PageMushaf.tsx` stop passing `getItemLayout` into the `FlatList` when `pageScroll === "horizontal"`, preserving `getItemLayout` only for vertical mode so vertical jumps still use precomputed offsets.
- Update the exposed `goToPageRef` behavior to use `scrollToOffset({ offset: width * (page - 1) })` when in horizontal mode and keep `scrollToIndex` for vertical mode.
- Add `horizontal` and `width` to the `goToPageRef` effect dependencies so go-to-page logic updates correctly when dimensions or mode change.

### Testing
- Ran `npx expo export --platform web` which completed and produced the web export (dist exists).
- Ran `npx tsc --noEmit` which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07b7811608326924b41445d2599d6)