### PR TITLE
Fix Mushaf chrome visibility to reveal only on explicit intent

### DIFF
--- a/app/(tabs)/mushaf.tsx
+++ b/app/(tabs)/mushaf.tsx
@@ -8,7 +8,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { FlashList, FlashListRef } from "@shopify/flash-list";
-import { useChrome, useChromeInactivity } from "@/lib/ui/chrome";
+import { useChrome } from "@/lib/ui/chrome";
 import { BookOpen, AlignJustify, Eye, EyeOff, Search, BookMarked } from "lucide-react-native";
 import { useDatabase } from "@/lib/database/provider";
 import { useSettings } from "@/lib/settings/context";
@@ -130,17 +130,37 @@ function MushafInner() {
   const isNarrow = windowWidth < 480;
   const { selection, toastMessage, dismissToast } = useSelection();
   const { navigateToAyah } = useWordInteraction();
-  const { visible: chromeVisible } = useChrome();
-  const markMushafActivity = useChromeInactivity();
+  const { visible: chromeVisible, setVisible: setChromeVisible } = useChrome();
+  const lastScrollYRef = useRef(0);
+  const touchStartYRef = useRef<number | null>(null);
+  const touchMovedRef = useRef(false);
+
+  const handleScrollReveal = useCallback((e: any) => {
+    const y = e?.nativeEvent?.contentOffset?.y;
+    if (typeof y !== "number") return;
+    if (y < lastScrollYRef.current) setChromeVisible(true);
+    lastScrollYRef.current = y;
+  }, [setChromeVisible]);
+
   const readerActivityProps = Platform.OS === "web"
     ? ({
-        onPointerDown: markMushafActivity,
-        onPointerMove: markMushafActivity,
-        onWheel: markMushafActivity,
+        onPointerDown: () => setChromeVisible(true),
       } as Record<string, unknown>)
     : ({
-        onTouchStart: markMushafActivity,
-        onTouchMove: markMushafActivity,
+        onTouchStart: (e: any) => {
+          touchStartYRef.current = e?.nativeEvent?.touches?.[0]?.pageY ?? null;
+          touchMovedRef.current = false;
+        },
+        onTouchMove: (e: any) => {
+          const y = e?.nativeEvent?.touches?.[0]?.pageY;
+          if (touchStartYRef.current != null && typeof y === "number" && Math.abs(y - touchStartYRef.current) > 8) {
+            touchMovedRef.current = true;
+          }
+        },
+        onTouchEnd: () => {
+          if (!touchMovedRef.current) setChromeVisible(true);
+          touchStartYRef.current = null;
+        },
       } as Record<string, unknown>);
 
   // Header slides/fades out AND collapses its height so the list fills the
@@ -708,8 +728,8 @@ function MushafInner() {
             <PageMushaf
               onPageChange={setCurrentPage}
               goToPageRef={goToPageRef}
-              onScroll={markMushafActivity}
-              onUserActivity={markMushafActivity}
+              onScroll={handleScrollReveal}
+              onUserActivity={() => setChromeVisible(true)}
               pagePaddingTop={isPhone ? 14 : 8}
               pagePaddingBottom={isPhone ? 12 : isTablet ? 0 : 32}
               scrollBottomInset={tabletScrollBottomInset}
@@ -790,7 +810,7 @@ function MushafInner() {
             keyExtractor={keyExtractor}
             extraData={{ fontSize, hideMode, highlightedKey }}
             contentContainerStyle={{ paddingBottom: isPhone ? 24 : 56 }}
-            onScroll={markMushafActivity}
+            onScroll={handleScrollReveal}
             scrollEventThrottle={16}
             onViewableItemsChanged={onViewableItemsChanged}
             viewabilityConfig={viewabilityConfig}
@@ -856,7 +876,7 @@ function MushafInner() {
             <MushafSlider
               currentPage={currentPage}
               interactive={chromeVisible}
-              onUserActivity={markMushafActivity}
+              onUserActivity={() => setChromeVisible(true)}
               onCommit={(p) => {
                 if (isPageMode) goToPageRef.current?.(p);
                 else {

--- a/lib/ui/chrome.tsx
+++ b/lib/ui/chrome.tsx
@@ -1,11 +1,10 @@
-import { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
-import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import { createContext, useContext, useState, useCallback } from "react";
 
 type ChromeContextType = {
   visible: boolean;
   setVisible: (v: boolean) => void;
   markActivity: () => void;
-  setAutoHideEnabled: (enabled: boolean) => void;
+  setAutoHideEnabled: (_enabled: boolean) => void;
 };
 
 const ChromeContext = createContext<ChromeContextType>({
@@ -15,8 +14,6 @@ const ChromeContext = createContext<ChromeContextType>({
   setAutoHideEnabled: () => {},
 });
 
-const INACTIVITY_HIDE_DELAY_MS = 2500;
-
 export function useChrome() {
   return useContext(ChromeContext);
 }
@@ -24,72 +21,18 @@ export function useChrome() {
 /** Provider for in-app chrome (top header + bottom tab bar) visibility. */
 export function ChromeProvider({ children }: { children: React.ReactNode }) {
   const [visible, setVisible] = useState(true);
-  const autoHideEnabledRef = useRef(false);
-  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearInactivityTimer = useCallback(() => {
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current);
-      hideTimerRef.current = null;
-    }
-  }, []);
-
-  const scheduleInactivityHide = useCallback(() => {
-    if (!autoHideEnabledRef.current) return;
-    clearInactivityTimer();
-    hideTimerRef.current = setTimeout(() => {
-      hideTimerRef.current = null;
-      if (autoHideEnabledRef.current) setVisible(false);
-    }, INACTIVITY_HIDE_DELAY_MS);
-  }, [clearInactivityTimer]);
 
   const markActivity = useCallback(() => {
     setVisible(true);
-    scheduleInactivityHide();
-  }, [scheduleInactivityHide]);
+  }, []);
 
-  const setAutoHideEnabled = useCallback(
-    (enabled: boolean) => {
-      autoHideEnabledRef.current = enabled;
-      clearInactivityTimer();
-      if (enabled) {
-        setVisible(true);
-        scheduleInactivityHide();
-      } else {
-        setVisible(true);
-      }
-    },
-    [clearInactivityTimer, scheduleInactivityHide]
-  );
-
-  useEffect(() => clearInactivityTimer, [clearInactivityTimer]);
+  const setAutoHideEnabled = useCallback((_enabled: boolean) => {
+    // Reader chrome no longer auto-hides on inactivity.
+  }, []);
 
   return (
     <ChromeContext.Provider value={{ visible, setVisible, markActivity, setAutoHideEnabled }}>
       {children}
     </ChromeContext.Provider>
-  );
-}
-
-/** Enables reader-style inactivity hiding while the current screen is mounted. */
-export function useChromeInactivity() {
-  const { markActivity, setAutoHideEnabled } = useChrome();
-
-  useEffect(() => {
-    setAutoHideEnabled(true);
-    markActivity();
-    return () => setAutoHideEnabled(false);
-  }, [markActivity, setAutoHideEnabled]);
-
-  return markActivity;
-}
-
-export function useHideChromeOnScroll() {
-  const markActivity = useChromeInactivity();
-  return useCallback(
-    (_e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      markActivity();
-    },
-    [markActivity]
   );
 }


### PR DESCRIPTION
### Motivation

- Reader chrome was hiding and revealing too eagerly (on small pointer moves, inactivity, or downward scroll) which produced a poor reading UX. 
- The goal is to stop automatic hide/unhide and only reveal chrome on explicit user intent (upward scroll, tap/click, or explicit control use) while preserving any manual hide/toggle and not changing layout. 
- Keep hidden chrome non-interactive and avoid introducing new visual/design changes.

### Description

- Removed inactivity-driven auto-hide logic from `ChromeProvider` by deleting the hide timer and making `markActivity()` only reveal chrome and `setAutoHideEnabled()` a no-op in `lib/ui/chrome.tsx` so the chrome no longer hides on inactivity. 
- Removed the `useChromeInactivity`/`useHideChromeOnScroll` behavior and switched Mushaf to directly use `useChrome()` with `setVisible` so reveal is explicit. 
- Implemented reveal-only handlers in `app/(tabs)/mushaf.tsx`: added `handleScrollReveal` that reveals chrome only when `contentOffset.y` decreases (upward scroll), and added web `onPointerDown` and touch `onTouchStart|onTouchMove|onTouchEnd` logic to treat a tap (no/low-movement) as explicit reveal while ignoring move/drag gestures. 
- Wired `PageMushaf` / `FlashList` `onScroll` and control `onUserActivity` callbacks to call `setVisible(true)` so explicit controls still reveal chrome, and preserved `pointerEvents` gating so hidden chrome remains non-interactive.

### Testing

- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm run build:web` (Expo web export) and the build/export completed and produced `dist`. 
- Created a local commit but `git push` to `origin` failed because no `origin` remote is configured in this environment, so the changes are committed locally but not pushed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02adc33ca883269b22fe3bc6ab28e6)