### PR TITLE
Migrate BookmarksSheet to shared responsive overlay

### DIFF
--- a/components/mushaf/BookmarksSheet.tsx
+++ b/components/mushaf/BookmarksSheet.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState, useCallback } from "react";
-import { View, Text, Pressable, Modal, ScrollView, useWindowDimensions } from "react-native";
-import { X, Trash2, BookmarkX } from "lucide-react-native";
+import { View, Text, Pressable, useWindowDimensions } from "react-native";
+import { Trash2, BookmarkX } from "lucide-react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { OverlayBody, OverlayHeader, ResponsiveSheet } from "@/components/ui/ResponsiveOverlay";
 import { useSelection } from "@/lib/selection/context";
 import { removeBookmark } from "@/lib/selection/queries";
 import { useDatabase } from "@/lib/database/provider";
 import { useSettings } from "@/lib/settings/context";
 import { useStrings } from "@/lib/i18n/useStrings";
+import { SIDEBAR_BREAKPOINT } from "@/lib/ui/viewport";
 
 type Props = {
   visible: boolean;
@@ -24,13 +27,15 @@ type BookmarkWithName = {
 
 export function BookmarksSheet({ visible, onClose, onNavigate }: Props) {
   const db = useDatabase();
-  const { isDark } = useSettings();
+  const { isDark, isRTL } = useSettings();
   const { width, height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
   const s = useStrings();
   const { bookmarksList, showToast, refreshBookmarks } = useSelection();
   const [enriched, setEnriched] = useState<BookmarkWithName[]>([]);
-  const modalWidth = Math.min(width - 32, 560);
-  const modalHeight = Math.min(height - 48, 640);
+  const isPhone = width < SIDEBAR_BREAKPOINT;
+  const maxOverlayHeight = Math.min(height - (isPhone ? 12 : 48), isPhone ? height * 0.94 : 640);
+  const surfaceColor = isDark ? "#1a1a1a" : "#FFF8F1";
 
   useEffect(() => {
     if (!visible || bookmarksList.length === 0) {
@@ -73,149 +78,110 @@ export function BookmarksSheet({ visible, onClose, onNavigate }: Props) {
   );
 
   return (
-    <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
-      <View
-        style={{
-          flex: 1,
-          alignItems: "center",
-          justifyContent: "center",
-          paddingHorizontal: 16,
-          backgroundColor: "rgba(0,0,0,0.45)",
+    <ResponsiveSheet
+      open={visible}
+      onClose={onClose}
+      maxWidth={560}
+      maxHeight={maxOverlayHeight}
+      surfaceColor={surfaceColor}
+    >
+      <OverlayHeader title={s.bookmarksTitle} onClose={onClose} showHandle={isPhone} isRTL={isRTL} />
+      <OverlayBody
+        contentContainerStyle={{
+          paddingHorizontal: 20,
+          paddingTop: 10,
+          paddingBottom: Math.max(insets.bottom, 12),
         }}
       >
-        <Pressable
-          style={{ position: "absolute", top: 0, right: 0, bottom: 0, left: 0 }}
-          onPress={onClose}
-        />
-        <View
-          style={{
-            width: modalWidth,
-            height: modalHeight,
-            backgroundColor: isDark ? "#1a1a1a" : "#FFF8F1",
-            borderRadius: 24,
-            paddingTop: 18,
-            paddingBottom: 20,
-            overflow: "hidden",
-          }}
-          onStartShouldSetResponder={() => true}
-        >
-          {/* Header */}
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              justifyContent: "space-between",
-              paddingHorizontal: 20,
-              paddingBottom: 16,
-            }}
-          >
-            <Text
-              style={{
-                fontFamily: "Manrope_700Bold",
-                fontSize: 18,
-                color: isDark ? "#e5e5e5" : "#2D2D2D",
-              }}
-            >
-              {s.bookmarksTitle}
-            </Text>
+        {enriched.length === 0 ? (
+          <EmptyState
+            icon={BookmarkX}
+            title={s.noBookmarks}
+            subtitle={s.emptyBookmarksSubtitle}
+            isDark={isDark}
+          />
+        ) : (
+          enriched.map((b) => (
             <Pressable
-              onPress={onClose}
+              key={`${b.surah}-${b.ayah}`}
+              onPress={() => handleTap(b.surah, b.ayah)}
               style={({ pressed }) => ({
-                padding: 8,
-                borderRadius: 20,
-                backgroundColor: isDark ? "#262626" : "#F0EAE2",
-                opacity: pressed ? 0.7 : 1,
+                flexDirection: isRTL ? "row-reverse" : "row",
+                alignItems: "center",
+                justifyContent: "space-between",
+                paddingVertical: 14,
+                paddingHorizontal: 4,
+                borderRadius: 12,
+                backgroundColor: pressed
+                  ? (isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.03)")
+                  : "transparent",
               })}
             >
-              <X size={18} color={isDark ? "#a3a3a3" : "#8B8178"} />
-            </Pressable>
-          </View>
-
-          {/* Bookmark list */}
-          <ScrollView style={{ paddingHorizontal: 20 }} contentContainerStyle={{ paddingBottom: 8 }}>
-            {enriched.length === 0 ? (
-              <EmptyState
-                icon={BookmarkX}
-                title={s.noBookmarks}
-                subtitle={s.emptyBookmarksSubtitle}
-                isDark={isDark}
-              />
-            ) : (
-              enriched.map((b) => (
-                <Pressable
-                  key={`${b.surah}-${b.ayah}`}
-                  onPress={() => handleTap(b.surah, b.ayah)}
-                  style={({ pressed }) => ({
-                    flexDirection: "row",
+              <View
+                style={{
+                  flexDirection: isRTL ? "row-reverse" : "row",
+                  alignItems: "center",
+                  gap: 12,
+                  flex: 1,
+                }}
+              >
+                <View
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 18,
+                    backgroundColor: isDark ? "rgba(253,220,145,0.12)" : "rgba(253,220,145,0.2)",
                     alignItems: "center",
-                    justifyContent: "space-between",
-                    paddingVertical: 14,
-                    paddingHorizontal: 4,
-                    borderRadius: 12,
-                    backgroundColor: pressed
-                      ? (isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.03)")
-                      : "transparent",
-                  })}
+                    justifyContent: "center",
+                  }}
                 >
-                  <View style={{ flexDirection: "row", alignItems: "center", gap: 12, flex: 1 }}>
-                    {/* Gold bookmark dot */}
-                    <View
-                      style={{
-                        width: 36,
-                        height: 36,
-                        borderRadius: 18,
-                        backgroundColor: isDark ? "rgba(253,220,145,0.12)" : "rgba(253,220,145,0.2)",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <Text
-                        style={{
-                          fontFamily: "Manrope_600SemiBold",
-                          fontSize: 11,
-                          color: "#FDDC91",
-                        }}
-                      >
-                        {b.surah}:{b.ayah}
-                      </Text>
-                    </View>
-                    <View style={{ flex: 1 }}>
-                      <Text
-                        style={{
-                          fontFamily: "Manrope_600SemiBold",
-                          fontSize: 14,
-                          color: isDark ? "#e5e5e5" : "#2D2D2D",
-                        }}
-                      >
-                        {b.surahNameArabic}
-                      </Text>
-                      <Text
-                        style={{
-                          fontFamily: "Manrope_400Regular",
-                          fontSize: 12,
-                          color: isDark ? "#737373" : "#A39B93",
-                        }}
-                      >
-                        {b.surahNameEnglish}
-                      </Text>
-                    </View>
-                  </View>
-                  <Pressable
-                    onPress={() => handleRemove(b.surah, b.ayah)}
-                    style={({ pressed }) => ({
-                      padding: 8,
-                      opacity: pressed ? 0.5 : 1,
-                    })}
-                    hitSlop={8}
+                  <Text
+                    style={{
+                      fontFamily: "Manrope_600SemiBold",
+                      fontSize: 11,
+                      color: "#FDDC91",
+                    }}
                   >
-                    <Trash2 size={16} color={isDark ? "#525252" : "#DFD9D1"} />
-                  </Pressable>
-                </Pressable>
-              ))
-            )}
-          </ScrollView>
-        </View>
-      </View>
-    </Modal>
+                    {b.surah}:{b.ayah}
+                  </Text>
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text
+                    style={{
+                      fontFamily: "Manrope_600SemiBold",
+                      fontSize: 14,
+                      color: isDark ? "#e5e5e5" : "#2D2D2D",
+                      textAlign: isRTL ? "right" : "left",
+                    }}
+                  >
+                    {b.surahNameArabic}
+                  </Text>
+                  <Text
+                    style={{
+                      fontFamily: "Manrope_400Regular",
+                      fontSize: 12,
+                      color: isDark ? "#737373" : "#A39B93",
+                      textAlign: isRTL ? "right" : "left",
+                    }}
+                  >
+                    {b.surahNameEnglish}
+                  </Text>
+                </View>
+              </View>
+              <Pressable
+                onPress={() => handleRemove(b.surah, b.ayah)}
+                style={({ pressed }) => ({
+                  padding: 8,
+                  opacity: pressed ? 0.5 : 1,
+                })}
+                hitSlop={8}
+              >
+                <Trash2 size={16} color={isDark ? "#525252" : "#DFD9D1"} />
+              </Pressable>
+            </Pressable>
+          ))
+        )}
+      </OverlayBody>
+    </ResponsiveSheet>
   );
 }


### PR DESCRIPTION
## Summary
- Migrated `components/mushaf/BookmarksSheet.tsx` from a bespoke `Modal` layout to the shared overlay system using:
  - `ResponsiveSheet`
  - `OverlayHeader`
  - `OverlayBody`
- Preserved the public API (`visible`, `onClose`, `onNavigate`) and all existing bookmark logic (query/enrichment, delete, refresh, navigate+close).

## Behavior updates
- Phone widths now render with the shared Hafiz sheet pattern (handle, internal scroll area, safe-area aware bottom padding).
- Tablet/desktop now render in the shared centered panel style with fully rounded corners and clipped scroll content.
- Close behavior now comes from shared overlay behavior:
  - close button works
  - backdrop dismiss works
  - Escape dismiss on web desktop works
- Preserved RTL/LTR and bilingual text behavior.

## Notes
- `npm run typecheck` completed successfully.
- `npm run build:web` was started but did not complete within the session window (continued rendering progress output without final success/failure line).
- Commit created locally on branch `work`: `5fee829`.
- Push to `main` could not be completed because no `origin` remote is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b138844c8326aef3bff6e8e437c7)