### PR TITLE
Replace platform Modals with ResponsiveSheet overlays and add RTL/viewport support in CreateDeckSheet and AyahBlock

### DIFF
--- a/components/flashcards/CreateDeckSheet.tsx
+++ b/components/flashcards/CreateDeckSheet.tsx
@@ -1,22 +1,15 @@
 import React, { useState, useEffect, useCallback } from "react";
-import {
-  View,
-  Text,
-  Modal,
-  Pressable,
-  ScrollView,
-  TextInput,
-  ActivityIndicator,
-} from "react-native";
-import { X, Check } from "lucide-react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { View, Text, Pressable, ScrollView, TextInput, ActivityIndicator, useWindowDimensions } from "react-native";
+import { Check } from "lucide-react-native";
 import { useDatabase } from "@/lib/database/provider";
 import { useSettings } from "@/lib/settings/context";
 import { useStrings } from "@/lib/i18n/useStrings";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
-import { createDeck, generateDeckId, resolveScope } from "@/lib/fsrs/queries";
+import { createDeck, generateDeckId } from "@/lib/fsrs/queries";
 import type { DeckScope } from "@/lib/fsrs/types";
+import { OverlayBody, OverlayFooter, OverlayHeader, ResponsiveSheet } from "@/components/ui/ResponsiveOverlay";
+import { SIDEBAR_BREAKPOINT } from "@/lib/ui/viewport";
 
 type ScopeType = "surah" | "juz" | "hizb" | "custom";
 
@@ -30,7 +23,9 @@ type SurahRow = { number: number; name_arabic: string; name_english: string; aya
 
 export function CreateDeckSheet({ visible, onClose, onCreated }: Props) {
   const db = useDatabase();
-  const { isDark } = useSettings();
+  const { isDark, isRTL } = useSettings();
+  const { width } = useWindowDimensions();
+  const isPhone = width < SIDEBAR_BREAKPOINT;
   const s = useStrings();
   const [scopeType, setScopeType] = useState<ScopeType>("surah");
   const [selectedSurahs, setSelectedSurahs] = useState<Set<number>>(new Set());
@@ -127,174 +122,98 @@ export function CreateDeckSheet({ visible, onClose, onCreated }: Props) {
   ];
 
   return (
-    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet">
-      <SafeAreaView
-        className="flex-1 bg-surface dark:bg-surface-dark"
-        edges={["top"]}
-      >
-        {/* Header */}
-        <View className="flex-row items-center justify-between px-6 py-4">
-          <Text
-            className="text-charcoal dark:text-neutral-100"
-            style={{ fontFamily: "NotoSerif_700Bold", fontSize: 22 }}
-          >
-            {s.flashcardsCreateDeckTitle}
-          </Text>
-          <Pressable onPress={onClose} className="w-10 h-10 rounded-full bg-surface-high dark:bg-surface-dark-high items-center justify-center">
-            <X size={18} color={isDark ? "#d4d4d4" : "#6e5a47"} />
-          </Pressable>
-        </View>
+    <ResponsiveSheet open={visible} onClose={onClose} maxWidth={760} maxHeight={720}>
+      <OverlayHeader
+        title={s.flashcardsCreateDeckTitle}
+        onClose={onClose}
+        isRTL={isRTL}
+        showHandle={isPhone}
+      />
 
-        {/* Scope type tabs */}
-        <View className="mb-4">
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{
-              gap: 8,
-              alignItems: "center",
-              paddingHorizontal: 24,
-              paddingVertical: 2,
-            }}
-            style={{ maxHeight: 52 }}
-          >
-            {SCOPE_TABS.map((tab) => (
-              <Pressable
-                key={tab.value}
-                onPress={() => setScopeType(tab.value)}
-                className={`h-11 rounded-full px-5 items-center justify-center ${
-                  scopeType === tab.value
-                    ? "bg-primary-accent"
-                    : "bg-surface-low dark:bg-surface-dark-low"
-                }`}
-                style={({ pressed }) => ({ transform: [{ scale: pressed ? 0.98 : 1 }] })}
-              >
-                <Text
-                  numberOfLines={1}
-                  style={{
-                    fontFamily: scopeType === tab.value ? "Manrope_600SemiBold" : "Manrope_500Medium",
-                    fontSize: 13,
-                    color: scopeType === tab.value ? "#fff" : (isDark ? "#a3a3a3" : "#6e5a47"),
-                  }}
-                >
-                  {tab.label}
-                </Text>
-              </Pressable>
-            ))}
-          </ScrollView>
-        </View>
-
-        {/* Content area */}
-        <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 120 }}>
-          {scopeType === "surah" && (
-            <View className="gap-2">
-              {surahs.map((s) => (
-                <SurahItem
-                  key={s.number}
-                  surah={s}
-                  selected={selectedSurahs.has(s.number)}
-                  onToggle={() => toggleSurah(s.number)}
-                  isDark={isDark}
-                />
-              ))}
-            </View>
-          )}
-
-          {scopeType === "juz" && (
-            <View className="flex-row flex-wrap gap-3">
-              {Array.from({ length: 30 }, (_, i) => i + 1).map((n) => (
-                <NumberChip
-                  key={n}
-                  number={n}
-                  selected={selectedJuz.has(n)}
-                  onToggle={() => toggleJuz(n)}
-                  isDark={isDark}
-                />
-              ))}
-            </View>
-          )}
-
-          {scopeType === "hizb" && (
-            <View className="flex-row flex-wrap gap-3">
-              {Array.from({ length: 60 }, (_, i) => i + 1).map((n) => (
-                <NumberChip
-                  key={n}
-                  number={n}
-                  selected={selectedHizb.has(n)}
-                  onToggle={() => toggleHizb(n)}
-                  isDark={isDark}
-                />
-              ))}
-            </View>
-          )}
-
-          {scopeType === "custom" && (
-            <Card elevation="low" className="p-5">
-              <Text
-                className="text-charcoal dark:text-neutral-300 mb-3"
-                style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14 }}
-              >
-                {s.flashcardsFrom}
-              </Text>
-              <View className="flex-row gap-3 mb-5">
-                <RangeInput
-                  label="Surah"
-                  value={customFrom.surah}
-                  onChangeText={(v) => setCustomFrom((p) => ({ ...p, surah: v }))}
-                  isDark={isDark}
-                />
-                <RangeInput
-                  label="Ayah"
-                  value={customFrom.ayah}
-                  onChangeText={(v) => setCustomFrom((p) => ({ ...p, ayah: v }))}
-                  isDark={isDark}
-                />
-              </View>
-              <Text
-                className="text-charcoal dark:text-neutral-300 mb-3"
-                style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14 }}
-              >
-                {s.flashcardsTo}
-              </Text>
-              <View className="flex-row gap-3">
-                <RangeInput
-                  label="Surah"
-                  value={customTo.surah}
-                  onChangeText={(v) => setCustomTo((p) => ({ ...p, surah: v }))}
-                  isDark={isDark}
-                />
-                <RangeInput
-                  label="Ayah"
-                  value={customTo.ayah}
-                  onChangeText={(v) => setCustomTo((p) => ({ ...p, ayah: v }))}
-                  isDark={isDark}
-                />
-              </View>
-            </Card>
-          )}
-        </ScrollView>
-
-        {/* Bottom action */}
-        <View
-          className="px-6 pb-6 pt-4"
-          style={{ backgroundColor: isDark ? "rgba(10,10,10,0.95)" : "rgba(255,248,241,0.95)" }}
+      <View className="mb-4 mt-2">
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{
+            gap: 8,
+            alignItems: "center",
+            paddingHorizontal: 20,
+            paddingVertical: 2,
+            flexDirection: isRTL ? "row-reverse" : "row",
+          }}
+          style={{ maxHeight: 52 }}
         >
-          <Button
-            onPress={handleCreate}
-            disabled={!canCreate() || creating}
-            className="w-full"
-          >
-            {creating ? (
-              <ActivityIndicator color="#fff" size="small" />
-            ) : (
-              <Text style={{ fontFamily: "Manrope_600SemiBold", fontSize: 16, color: "#fff" }}>
-                {s.flashcardsCreate}
+          {SCOPE_TABS.map((tab) => (
+            <Pressable
+              key={tab.value}
+              onPress={() => setScopeType(tab.value)}
+              className={`h-11 rounded-full px-5 items-center justify-center ${
+                scopeType === tab.value ? "bg-primary-accent" : "bg-surface-low dark:bg-surface-dark-low"
+              }`}
+              style={({ pressed }) => ({ transform: [{ scale: pressed ? 0.98 : 1 }] })}
+            >
+              <Text
+                numberOfLines={1}
+                style={{
+                  fontFamily: scopeType === tab.value ? "Manrope_600SemiBold" : "Manrope_500Medium",
+                  fontSize: 13,
+                  color: scopeType === tab.value ? "#fff" : (isDark ? "#a3a3a3" : "#6e5a47"),
+                }}
+              >
+                {tab.label}
               </Text>
-            )}
-          </Button>
-        </View>
-      </SafeAreaView>
-    </Modal>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </View>
+
+      <OverlayBody contentContainerClassName="px-5 pb-8">
+        {scopeType === "surah" && (
+          <View className="gap-2">
+            {surahs.map((s) => (
+              <SurahItem key={s.number} surah={s} selected={selectedSurahs.has(s.number)} onToggle={() => toggleSurah(s.number)} isDark={isDark} />
+            ))}
+          </View>
+        )}
+
+        {scopeType === "juz" && (
+          <View className="flex-row flex-wrap gap-3">
+            {Array.from({ length: 30 }, (_, i) => i + 1).map((n) => (
+              <NumberChip key={n} number={n} selected={selectedJuz.has(n)} onToggle={() => toggleJuz(n)} isDark={isDark} />
+            ))}
+          </View>
+        )}
+
+        {scopeType === "hizb" && (
+          <View className="flex-row flex-wrap gap-3">
+            {Array.from({ length: 60 }, (_, i) => i + 1).map((n) => (
+              <NumberChip key={n} number={n} selected={selectedHizb.has(n)} onToggle={() => toggleHizb(n)} isDark={isDark} />
+            ))}
+          </View>
+        )}
+
+        {scopeType === "custom" && (
+          <Card elevation="low" className="p-5">
+            <Text className="text-charcoal dark:text-neutral-300 mb-3" style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14 }}>{s.flashcardsFrom}</Text>
+            <View className="flex-row gap-3 mb-5">
+              <RangeInput label="Surah" value={customFrom.surah} onChangeText={(v) => setCustomFrom((p) => ({ ...p, surah: v }))} isDark={isDark} />
+              <RangeInput label="Ayah" value={customFrom.ayah} onChangeText={(v) => setCustomFrom((p) => ({ ...p, ayah: v }))} isDark={isDark} />
+            </View>
+            <Text className="text-charcoal dark:text-neutral-300 mb-3" style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14 }}>{s.flashcardsTo}</Text>
+            <View className="flex-row gap-3">
+              <RangeInput label="Surah" value={customTo.surah} onChangeText={(v) => setCustomTo((p) => ({ ...p, surah: v }))} isDark={isDark} />
+              <RangeInput label="Ayah" value={customTo.ayah} onChangeText={(v) => setCustomTo((p) => ({ ...p, ayah: v }))} isDark={isDark} />
+            </View>
+          </Card>
+        )}
+      </OverlayBody>
+
+      <OverlayFooter isRTL={isRTL}>
+        <Button onPress={handleCreate} disabled={!canCreate() || creating} className="w-full">
+          {creating ? <ActivityIndicator color="#fff" size="small" /> : <Text style={{ fontFamily: "Manrope_600SemiBold", fontSize: 16, color: "#fff" }}>{s.flashcardsCreate}</Text>}
+        </Button>
+      </OverlayFooter>
+    </ResponsiveSheet>
   );
 }
 

--- a/components/mushaf/AyahBlock.tsx
+++ b/components/mushaf/AyahBlock.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef, useMemo, memo } from "react";
-import { View, Text, Pressable, Animated as RNAnimated, useWindowDimensions, Modal, ScrollView, TextInput } from "react-native";
+import { View, Text, Pressable, Animated as RNAnimated, useWindowDimensions, TextInput } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -33,7 +33,7 @@ import {
 import { formatForCopy } from "@/lib/selection/format";
 import { SIDEBAR_BREAKPOINT } from "@/lib/ui/viewport";
 import { AyahDetailModal } from "./AyahDetailModal";
-import { X } from "lucide-react-native";
+import { OverlayBody, OverlayHeader, ResponsiveSheet } from "@/components/ui/ResponsiveOverlay";
 
 type DeckOption = {
   id: string;
@@ -416,74 +416,49 @@ function AyahBlockInner({
         onClose={() => setDetailOpen(false)}
         initialTab={detailTab}
       />
-      <Modal visible={deckPickerOpen} transparent animationType="fade" onRequestClose={() => setDeckPickerOpen(false)}>
-        <View className="flex-1 items-center justify-center px-4" style={{ backgroundColor: "rgba(0,0,0,0.55)" }}>
-          <Pressable className="absolute inset-0" onPress={() => setDeckPickerOpen(false)} />
-          <View className="w-full max-w-[560px] rounded-3xl bg-surface dark:bg-surface-dark p-5">
-            <View className={isRTL ? "flex-row-reverse items-center justify-between" : "flex-row items-center justify-between"}>
-              <Text className="text-charcoal dark:text-neutral-100" style={{ fontFamily: "NotoSerif_700Bold", fontSize: 22 }}>
-                {s.reviewSelectDeck ?? s.flashcardsDecks}
+      <ResponsiveSheet open={deckPickerOpen} onClose={() => setDeckPickerOpen(false)} maxWidth={560} maxHeight={640}>
+        <OverlayHeader
+          title={s.reviewSelectDeck ?? s.flashcardsDecks}
+          onClose={() => setDeckPickerOpen(false)}
+          isRTL={isRTL}
+          showHandle={isPhone}
+        />
+        <OverlayBody contentContainerClassName="px-5 pb-5 pt-4">
+          <View className="rounded-2xl bg-surface-low dark:bg-surface-dark-low p-3">
+            <TextInput
+              value={newDeckName}
+              onChangeText={setNewDeckName}
+              placeholder={s.reviewNewDeckName}
+              placeholderTextColor={isDark ? "#525252" : "#b9a085"}
+              className="rounded-xl bg-surface dark:bg-surface-dark px-3 py-2 text-charcoal dark:text-neutral-100"
+              style={{ fontFamily: "Manrope_500Medium", fontSize: 14, textAlign: isRTL ? "right" : "left", writingDirection: isRTL ? "rtl" : "ltr" }}
+            />
+            <Pressable
+              onPress={handleCreateDeckAndAdd}
+              disabled={reviewBusy || newDeckName.trim().length === 0}
+              className="mt-3 rounded-2xl bg-primary-soft px-4 py-3"
+              style={({ pressed }) => ({ transform: [{ scale: pressed ? 0.98 : 1 }], opacity: reviewBusy || newDeckName.trim().length === 0 ? 0.55 : 1 })}
+            >
+              <Text className="text-gold" style={{ fontFamily: "Manrope_700Bold", fontSize: 14, textAlign: isRTL ? "right" : "left" }}>
+                {s.reviewCreateAndSelectDeck}
               </Text>
-              <Pressable onPress={() => setDeckPickerOpen(false)} className="h-9 w-9 items-center justify-center rounded-full bg-surface-low dark:bg-surface-dark-low">
-                <X size={16} color={isDark ? "#a3a3a3" : "#6e5a47"} />
-              </Pressable>
-            </View>
-            <View className="mt-4 rounded-2xl bg-surface-low dark:bg-surface-dark-low p-3">
-              <TextInput
-                value={newDeckName}
-                onChangeText={setNewDeckName}
-                placeholder={s.reviewNewDeckName}
-                placeholderTextColor={isDark ? "#525252" : "#b9a085"}
-                className="rounded-xl bg-surface dark:bg-surface-dark px-3 py-2 text-charcoal dark:text-neutral-100"
-                style={{
-                  fontFamily: "Manrope_500Medium",
-                  fontSize: 14,
-                  textAlign: isRTL ? "right" : "left",
-                  writingDirection: isRTL ? "rtl" : "ltr",
-                }}
-              />
-              <Pressable
-                onPress={handleCreateDeckAndAdd}
-                disabled={reviewBusy || newDeckName.trim().length === 0}
-                className="mt-3 rounded-2xl bg-primary-soft px-4 py-3"
-                style={({ pressed }) => ({
-                  transform: [{ scale: pressed ? 0.98 : 1 }],
-                  opacity: reviewBusy || newDeckName.trim().length === 0 ? 0.55 : 1,
-                })}
-              >
-                <Text className="text-gold" style={{ fontFamily: "Manrope_700Bold", fontSize: 14, textAlign: isRTL ? "right" : "left" }}>
-                  {s.reviewCreateAndSelectDeck}
-                </Text>
-              </Pressable>
-            </View>
-            <ScrollView style={{ maxHeight: 280, marginTop: 10 }}>
-              {deckLoading ? (
-                <Text className="text-warm-500 dark:text-neutral-400" style={{ fontFamily: "Manrope_500Medium", fontSize: 13 }}>
-                  {s.loading}
-                </Text>
-              ) : deckOptions.length === 0 ? (
-                <Text className="text-warm-500 dark:text-neutral-400" style={{ fontFamily: "Manrope_500Medium", fontSize: 13 }}>
-                  {s.flashcardsNoDecks}
-                </Text>
-              ) : (
-                deckOptions.map((deck) => (
-                  <Pressable
-                    key={deck.id}
-                    onPress={() => handleAddToExistingDeck(deck.id)}
-                    disabled={reviewBusy}
-                    className="mb-2 rounded-2xl bg-surface-low dark:bg-surface-dark-low px-4 py-3"
-                    style={({ pressed }) => ({ transform: [{ scale: pressed ? 0.99 : 1 }], opacity: reviewBusy ? 0.7 : 1 })}
-                  >
-                    <Text className="text-charcoal dark:text-neutral-100" style={{ fontFamily: "Manrope_600SemiBold", fontSize: 13 }}>
-                      {formatDeckLabel(deck)}
-                    </Text>
-                  </Pressable>
-                ))
-              )}
-            </ScrollView>
+            </Pressable>
           </View>
-        </View>
-      </Modal>
+          <View className="mt-3">
+            {deckLoading ? (
+              <Text className="text-warm-500 dark:text-neutral-400" style={{ fontFamily: "Manrope_500Medium", fontSize: 13 }}>{s.loading}</Text>
+            ) : deckOptions.length === 0 ? (
+              <Text className="text-warm-500 dark:text-neutral-400" style={{ fontFamily: "Manrope_500Medium", fontSize: 13 }}>{s.flashcardsNoDecks}</Text>
+            ) : (
+              deckOptions.map((deck) => (
+                <Pressable key={deck.id} onPress={() => handleAddToExistingDeck(deck.id)} disabled={reviewBusy} className="mb-2 rounded-2xl bg-surface-low dark:bg-surface-dark-low px-4 py-3" style={({ pressed }) => ({ transform: [{ scale: pressed ? 0.99 : 1 }], opacity: reviewBusy ? 0.7 : 1 })}>
+                  <Text className="text-charcoal dark:text-neutral-100" style={{ fontFamily: "Manrope_600SemiBold", fontSize: 13 }}>{formatDeckLabel(deck)}</Text>
+                </Pressable>
+              ))
+            )}
+          </View>
+        </OverlayBody>
+      </ResponsiveSheet>
     </View>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace platform `Modal`-based overlays with a reusable responsive overlay component to unify UI and support larger sheet sizes and consistent headers/footers.
- Improve layout behavior for RTL locales and adapt UI to different viewport sizes using the existing `SIDEBAR_BREAKPOINT`.

### Description
- Replaced `Modal`/`SafeAreaView` usage in `CreateDeckSheet` with `ResponsiveSheet`, `OverlayHeader`, `OverlayBody`, and `OverlayFooter`, and moved bottom action into the overlay footer.
- Added viewport awareness (`useWindowDimensions`, `SIDEBAR_BREAKPOINT`) and RTL support (`isRTL`) to adjust layout, handle visibility of the drag handle, and flip horizontal scroll direction in scope tabs.
- Migrated the deck picker in `AyahBlock` from a `Modal` to `ResponsiveSheet`, moved header/inputs into `OverlayHeader`/`OverlayBody`, and removed the inline close `X` button in favor of the overlay header close action.
- Adjusted imports and removed unused items (`resolveScope`, modal-specific imports, and the `X` icon) and updated styles/props for new overlay components and inputs.

### Testing
- Ran TypeScript compilation with `yarn tsc --noEmit` and it succeeded.
- Ran linting with `yarn lint` and no new lint errors were reported.
- Ran the test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b936391083268cce52e91402e662)