### PR TITLE
Refactor WriteReflectionSheet to ResponsiveSheet overlay primitives

### DIFF
--- a/components/reflections/WriteReflectionSheet.tsx
+++ b/components/reflections/WriteReflectionSheet.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
-import { View, Text, TextInput, Pressable, ActivityIndicator } from "react-native";
-import { Sheet, SheetHeader, SheetContent } from "@/components/ui/Sheet";
+import { View, Text, TextInput, Pressable, ActivityIndicator, useWindowDimensions } from "react-native";
+import { OverlayBody, OverlayHeader, ResponsiveSheet } from "@/components/ui/ResponsiveOverlay";
 import { useAuthStore } from "@/lib/auth/store";
 import { useSettings } from "@/lib/settings/context";
 import { useStrings } from "@/lib/i18n/useStrings";
@@ -8,6 +8,7 @@ import { createReflection } from "@/lib/reflections/api";
 import { useQueryClient } from "@tanstack/react-query";
 import { interpolate } from "@/lib/i18n/useStrings";
 import { router } from "expo-router";
+import { SIDEBAR_BREAKPOINT } from "@/lib/ui/viewport";
 
 type Props = {
   open: boolean;
@@ -28,7 +29,8 @@ export function WriteReflectionSheet({
   ayahPreview,
   onSuccess,
 }: Props) {
-  const { isDark } = useSettings();
+  const { isDark, isRTL } = useSettings();
+  const { width, height } = useWindowDimensions();
   const s = useStrings();
   const user = useAuthStore((s) => s.user);
   const queryClient = useQueryClient();
@@ -36,6 +38,9 @@ export function WriteReflectionSheet({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const isPhone = width < SIDEBAR_BREAKPOINT;
+  const maxOverlayHeight = Math.min(height - (isPhone ? 12 : 48), isPhone ? height * 0.94 : 640);
+  const surfaceColor = isDark ? "#1a1a1a" : "#FFF8F1";
   const mutedColor = isDark ? "#737373" : "#A39B93";
   const charCount = content.length;
   const isValid = charCount >= 10 && charCount <= 5000;
@@ -76,34 +81,31 @@ export function WriteReflectionSheet({
   }, [handleClose]);
 
   return (
-    <Sheet open={open} onClose={handleClose}>
-      <SheetHeader>
-        <View className="items-center">
-          <Text
-            style={{
-              fontFamily: "Manrope_600SemiBold",
-              fontSize: 10,
-              letterSpacing: 1.6,
-              textTransform: "uppercase",
-              color: mutedColor,
-            }}
-          >
-            {s.reflections}
-          </Text>
-          <Text
-            className="text-charcoal dark:text-neutral-100"
-            style={{ fontFamily: "NotoSerif_700Bold", fontSize: 24, marginTop: 6 }}
-          >
-            {s.addReflection}
-          </Text>
-        </View>
-      </SheetHeader>
-      <SheetContent>
+    <ResponsiveSheet
+      open={open}
+      onClose={handleClose}
+      maxWidth={560}
+      maxHeight={maxOverlayHeight}
+      surfaceColor={surfaceColor}
+    >
+      <OverlayHeader
+        title={s.addReflection}
+        subtitle={s.reflections}
+        onClose={handleClose}
+        showHandle={isPhone}
+        isRTL={isRTL}
+      />
+      <OverlayBody contentContainerClassName="px-5 pb-6">
         {!user ? (
-          /* Not logged in */
           <View className="items-center py-4">
             <Text
-              style={{ fontFamily: "Manrope_400Regular", fontSize: 14, color: mutedColor, marginBottom: 12 }}
+              style={{
+                fontFamily: "Manrope_400Regular",
+                fontSize: 14,
+                color: mutedColor,
+                marginBottom: 12,
+                textAlign: isRTL ? "right" : "left",
+              }}
             >
               {s.reflectionLoginRequired}
             </Text>
@@ -112,16 +114,11 @@ export function WriteReflectionSheet({
               className="rounded-full bg-primary-accent dark:bg-primary-bright px-6 py-3"
               style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}
             >
-              <Text
-                style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14, color: "#FFFFFF" }}
-              >
-                {s.authLogin}
-              </Text>
+              <Text style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14, color: "#FFFFFF" }}>{s.authLogin}</Text>
             </Pressable>
           </View>
         ) : (
           <>
-            {/* Ayah reference */}
             {ayahPreview && (
               <View className="rounded-2xl bg-surface-low dark:bg-surface-dark-low px-3.5 py-3 mb-3">
                 <Text
@@ -132,20 +129,20 @@ export function WriteReflectionSheet({
                     letterSpacing: 1,
                     textTransform: "uppercase",
                     marginBottom: 4,
+                    textAlign: isRTL ? "right" : "left",
                   }}
                 >
                   {s.reflectionAyahLabel}
                 </Text>
                 <Text
                   className="text-warm-500 dark:text-neutral-400"
-                  style={{ fontFamily: "NotoSerif_700Bold", fontSize: 15 }}
+                  style={{ fontFamily: "NotoSerif_700Bold", fontSize: 15, textAlign: isRTL ? "right" : "left" }}
                 >
                   {ayahPreview}
                 </Text>
               </View>
             )}
 
-            {/* Text area */}
             <TextInput
               value={content}
               onChangeText={setContent}
@@ -161,10 +158,10 @@ export function WriteReflectionSheet({
                 lineHeight: 22,
                 minHeight: 132,
                 maxHeight: 220,
+                textAlign: isRTL ? "right" : "left",
               }}
             />
 
-            {/* Character count */}
             <View className="flex-row items-center justify-between mb-3">
               <Text
                 style={{
@@ -182,7 +179,6 @@ export function WriteReflectionSheet({
               )}
             </View>
 
-            {/* Error message */}
             {error && (
               <Text
                 style={{
@@ -190,13 +186,13 @@ export function WriteReflectionSheet({
                   fontSize: 12,
                   color: "#ef4444",
                   marginBottom: 8,
+                  textAlign: isRTL ? "right" : "left",
                 }}
               >
                 {error}
               </Text>
             )}
 
-            {/* Submit button */}
             <Pressable
               onPress={handleSubmit}
               disabled={!isValid || submitting}
@@ -208,16 +204,11 @@ export function WriteReflectionSheet({
               {submitting ? (
                 <ActivityIndicator size="small" color="#FFFFFF" />
               ) : (
-                <Text
-                  style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14, color: "#FFFFFF" }}
-                >
-                  {s.reflectionSubmit}
-                </Text>
+                <Text style={{ fontFamily: "Manrope_600SemiBold", fontSize: 14, color: "#FFFFFF" }}>{s.reflectionSubmit}</Text>
               )}
             </Pressable>
           </>
         )}
-      </SheetContent>
-    </Sheet>
-  );
-}
+      </OverlayBody>
+    </ResponsiveSheet>
+  );}


### PR DESCRIPTION
### Motivation
- Convert an older `Sheet/SheetHeader/SheetContent` overlay to the new responsive overlay primitives used across the app so behavior and sizing match other migrated overlays.
- Ensure consistent phone vs desktop behaviour using the shared `SIDEBAR_BREAKPOINT` breakpoint and keep internal scrolling scoped to the overlay body.

### Description
- Replaced `Sheet`, `SheetHeader`, and `SheetContent` with `ResponsiveSheet`, `OverlayHeader`, and `OverlayBody` in `components/reflections/WriteReflectionSheet.tsx`.
- Wire `open={open}` and `onClose={handleClose}` on `ResponsiveSheet`, computed `maxHeight`/`maxWidth` to match other overlays, and passed `surfaceColor` for theme parity.
- Use `useWindowDimensions()` + `SIDEBAR_BREAKPOINT` to derive `isPhone` and pass `showHandle={isPhone}` to preserve rounded corners and phone handle behavior; `OverlayHeader` uses `title`/`subtitle` instead of children.
- Move all content inside `OverlayBody` so scrolling is internal, add consistent RTL/LTR alignment (header, ayah label/preview, textarea, login prompt, error text), and ensure all close paths (sheet close, header close, ESC/backdrop) call `handleClose` which resets the form state.

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully.
- Ran `npm run build:web` and the web export completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035f9715c48326a02d30b597a1d39e)