### PR TITLE
Use dialog desktop presentation for GoTo navigator overlay

### DIFF
--- a/components/mushaf/GoToNavigator.tsx
+++ b/components/mushaf/GoToNavigator.tsx
@@ -44,8 +44,9 @@ export function GoToNavigator({
   const db = useDatabase();
   const s = useStrings();
   const { isDark, isRTL } = useSettings();
-  const { width } = useWindowDimensions();
+  const { width, height } = useWindowDimensions();
   const isPhone = width < SIDEBAR_BREAKPOINT;
+  const overlayMaxHeight = isPhone ? "88%" : Math.min(Math.floor(height * 0.88), 820);
   const [surahs, setSurahs] = useState<SurahRow[]>([]);
   const [juzList, setJuzList] = useState<JuzInfo[]>([]);
   const [surahPageMap, setSurahPageMap] = useState<Map<number, number>>(new Map());
@@ -307,9 +308,10 @@ export function GoToNavigator({
       onClose={onClose}
       phonePresentation="sheet"
       desktopPresentation="dialog"
-      maxWidth={520}
-      maxHeight="88%"
+      maxWidth={560}
+      maxHeight={overlayMaxHeight}
       dismissOnBackdrop
+      dismissOnEscape
       surfaceColor={isDark ? "#1C1917" : "#FFF8F1"}
     >
       <OverlayHeader title={s.goToTitle} onClose={onClose} showHandle={isPhone} isRTL={isRTL} />


### PR DESCRIPTION
### Motivation
- Make the GoTo navigator present as a centered dialog on tablet/desktop while preserving the bottom-sheet behaviour on phones, keeping backdrop/ESC dismissal, and ensuring content remains internally scrollable.

### Description
- Keep `ResponsiveOverlay` with `phonePresentation="sheet"` and `desktopPresentation="dialog"`, explicitly enable `dismissOnBackdrop` and `dismissOnEscape`, and preserve existing `onClose` callbacks.
- Read `height` from `useWindowDimensions()` and compute `overlayMaxHeight = isPhone ? "88%" : Math.min(Math.floor(height * 0.88), 820)`, and increase `maxWidth` to `560` so the dialog fits desktop layouts without forcing outer overflow.

### Testing
- Ran `npm run typecheck` and `npm run build:web`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035f9c183c83268b3e40e68d165232)