### PR TITLE
Fix missing updated_at migrations for legacy SQLite tables

### DIFF
--- a/lib/database/init.ts
+++ b/lib/database/init.ts
@@ -1148,10 +1148,18 @@ async function ensureQfUserSyncSchema(db: SQLiteDatabase): Promise<void> {
   try { await db.execAsync("ALTER TABLE bookmarks ADD COLUMN qf_collections_count INTEGER NOT NULL DEFAULT 0"); } catch (_) {}
   await db.execAsync("UPDATE bookmarks SET updated_at = created_at WHERE updated_at IS NULL");
 
+  try { await db.execAsync("ALTER TABLE study_cards ADD COLUMN updated_at TEXT"); } catch (_) {}
+  await db.execAsync("UPDATE study_cards SET updated_at = created_at WHERE updated_at IS NULL");
+
+  try { await db.execAsync("ALTER TABLE private_notes ADD COLUMN updated_at TEXT"); } catch (_) {}
+  await db.execAsync("UPDATE private_notes SET updated_at = created_at WHERE updated_at IS NULL");
   try { await db.execAsync("ALTER TABLE private_notes ADD COLUMN qf_note_id TEXT"); } catch (_) {}
   try { await db.execAsync("ALTER TABLE private_notes ADD COLUMN qf_synced_at TEXT"); } catch (_) {}
   try { await db.execAsync("ALTER TABLE private_notes ADD COLUMN qf_sync_error TEXT"); } catch (_) {}
   try { await db.execAsync("ALTER TABLE private_notes ADD COLUMN qf_ranges_json TEXT"); } catch (_) {}
+
+  try { await db.execAsync("ALTER TABLE reflection_journey_entries ADD COLUMN updated_at TEXT"); } catch (_) {}
+  await db.execAsync("UPDATE reflection_journey_entries SET updated_at = created_at WHERE updated_at IS NULL");
 
   await db.execAsync(`
     CREATE TABLE IF NOT EXISTS qf_sync_queue (


### PR DESCRIPTION
### Motivation
- Older local SQLite installs were crashing on startup with `Error code 1: no such column: updated_at` because sync and pull logic assume `updated_at` exists on several tables. 
- Ensure startup migration is defensive so existing users with older DBs can open the app and continue syncing without manual fixes.

### Description
- Add defensive `ALTER TABLE` migrations in `ensureQfUserSyncSchema` to create `updated_at` on `study_cards`, `private_notes`, and `reflection_journey_entries` if missing. 
- Backfill `updated_at` from `created_at` for the newly-added columns so existing rows have valid timestamps. 
- Keep the existing `bookmarks` migration and qf sync queue creation in the same initialization flow so all qf-related schema work runs on startup. 
- Change is implemented in `lib/database/init.ts` (migration block around L1141–L1163).

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully. 
- Ran `npm run build:web` and the web export completed with generated bundles and static routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0845c23cbc83269e9329cca009d832)