### PR TITLE
Align settings switches opposite labels for uniform layout

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1111,7 +1111,7 @@ function SettingsSwitchRow({
 }) {
   return (
     <View
-      className="items-center gap-3 rounded-2xl bg-surface dark:bg-surface-dark px-3 py-2.5"
+      className="items-center justify-between rounded-2xl bg-surface dark:bg-surface-dark px-3 py-2.5"
       style={{
         flexDirection: isRTL ? "row-reverse" : "row",
         width: compact ? "48%" : "100%",
@@ -1121,6 +1121,7 @@ function SettingsSwitchRow({
         className="text-charcoal dark:text-neutral-300"
         style={{
           color: isDark ? "#d4d4d4" : "#2D2D2D",
+          flex: 1,
           flexShrink: 1,
           fontFamily: "Manrope_500Medium",
           fontSize: 14,


### PR DESCRIPTION
### Motivation
- Ensure toggles are consistently placed opposite their labels across LTR/RTL and compact layouts for a uniform settings UI.

### Description
- In `app/(tabs)/settings.tsx` update `SettingsSwitchRow` to add `justify-between` to the row container and set the label `Text` to `flex: 1` so the switch stays at the far edge and spacing is consistent.

### Testing
- Ran `npm run typecheck` which completed successfully, and `npm run build:web` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8a947f7c83269b8f32547db654e9)